### PR TITLE
imx-kobs: support burn images to imx8mq ddr4 arm2 NAND

### DIFF
--- a/src/mtd.h
+++ b/src/mtd.h
@@ -226,6 +226,7 @@ enum {
 	ROM_Version_3	    =  3, /* e.g., i.MX50, iMX6dqsl */
 	ROM_Version_4	    =  4, /* e.g., i.MX6sx */
 	ROM_Version_5	    =  5, /* e.g., i.MX6sx TO1.2*/
+	ROM_Version_6	    =  6, /* e.g., i.MX8MQ*/
 };
 
 static inline int mtd_pages_per_block(struct mtd_data *md)
@@ -307,6 +308,7 @@ int v3_rom_mtd_commit_structures(struct mtd_data *md, FILE *fp, int flags);
 int v4_rom_mtd_commit_structures(struct mtd_data *md, FILE *fp, int flags);
 int v5_rom_mtd_commit_structures(struct mtd_data *md, FILE *fp, int flags);
 int v6_rom_mtd_commit_structures(struct mtd_data *md, FILE *fp, int flags);
+int v7_rom_mtd_commit_structures(struct mtd_data *md, FILE *fp, int flags);
 
 int mtd_set_ecc_mode(struct mtd_data *md, int ecc);
 

--- a/src/plat_boot_config.c
+++ b/src/plat_boot_config.c
@@ -163,7 +163,7 @@ static platform_config mx6ul_boot_config = {
 	.rom_mtd_commit_structures = v6_rom_mtd_commit_structures,
 };
 
-static platform_config mx8_boot_config = {
+static platform_config mx8q_boot_config = {
 	.m_u32RomVer = ROM_Version_5,
 	.m_u32EnDISBBM = 0,
 	.m_u32EnBootStreamVerify = 0,
@@ -174,6 +174,19 @@ static platform_config mx8_boot_config = {
 	.m_u32MaxEccStrength = 62,
 	.rom_mtd_init = v4_rom_mtd_init,
 	.rom_mtd_commit_structures = v5_rom_mtd_commit_structures,
+};
+
+static platform_config mx8mq_boot_config = {
+	.m_u32RomVer = ROM_Version_6,
+	.m_u32EnDISBBM = 0,
+	.m_u32EnBootStreamVerify = 0,
+	.m_u32UseNfcGeo = 0,
+	.m_u32UseMultiBootArea = 0,
+	.m_u32UseSinglePageStride = 0,
+	.m_u32DBBT_FingerPrint = DBBT_FINGERPRINT2,
+	.m_u32MaxEccStrength = 62,
+	.rom_mtd_init = v4_rom_mtd_init,
+	.rom_mtd_commit_structures = v7_rom_mtd_commit_structures,
 };
 
 int discover_boot_rom_version(void)
@@ -187,20 +200,29 @@ int discover_boot_rom_version(void)
 	static char  *plat_imx6sx = "i.MX6SX";
 	static char  *plat_imx6ul = "i.MX6UL";
 	static char  *plat_imx6ull = "i.MX6ULL";
-	static char  *plat_imx8 = "i.MX8";
+	static char  *plat_imx8q = "i.MX8Q"; /* i.MX8QM or i.MX8QXP */
+	static char  *plat_imx8mq = "i.MX8MQ"; /* i.MX8MQ(mscale) */
 	char *rev;
 	int system_rev, hw_system_rev = 0;
 
 
 	/* check if it is i.MX8 platform */
 	soc_id = fopen("/sys/devices/soc0/soc_id", "r");
+
 	if (soc_id) {
 		fgets(line_buffer, sizeof(line_buffer), soc_id);
 		fclose(soc_id);
 
-		if (!strncmp(line_buffer, plat_imx8, strlen(plat_imx8))) {
-			plat_config_data = &mx8_boot_config;
-			plat_config_data->m_u32Arm_type = MX8;
+		if (!strncmp(line_buffer, plat_imx8q, strlen(plat_imx8q))) {
+
+			plat_config_data = &mx8q_boot_config;
+			plat_config_data->m_u32Arm_type = MX8Q;
+			return 0;
+
+		} else if (!strncmp(line_buffer, plat_imx8mq, strlen(plat_imx8mq))) {
+
+			plat_config_data = &mx8mq_boot_config;
+			plat_config_data->m_u32Arm_type = MX8MQ;
 			return 0;
 		}
 

--- a/src/plat_boot_config.h
+++ b/src/plat_boot_config.h
@@ -45,7 +45,9 @@
 #define MX6DL	0x61
 
 #define MX7	0x7
-#define MX8	0x8
+
+#define MX8Q	0x8
+#define MX8MQ	0x81
 
 typedef struct _platform_config_t {
 	uint32_t m_u32RomVer;


### PR DESCRIPTION
add the new platform config for imx8mq and also change the code to burn
multiple firmwares and boot images

Signed-off-by: Han Xu <han.xu@nxp.com>